### PR TITLE
Fix/event membership dream

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,3 +1,5 @@
 MONGO_URL="mongodb://root:example@localhost:27017"
 JWT_SECRET="xxx"
 MAILGUN_API_KEY="xxx"
+PRETIX_URL="xxx"
+PRETIX_TOKEN="xxx"

--- a/ui/components/Comment.js
+++ b/ui/components/Comment.js
@@ -45,7 +45,7 @@ const Comment = ({ comment, dreamId, currentUser, showBorderBottom }) => {
         <p className="text-gray-900">{comment.content}</p>
         {currentUser &&
           (currentUser.id === comment.author.id ||
-            currentUser.membership.isAdmin) && (
+            (currentUser.membership && currentUser.membership.isAdmin)) && (
             <button
               onClick={() => {
                 if (

--- a/ui/utils/helpers.js
+++ b/ui/utils/helpers.js
@@ -6,7 +6,7 @@
 // };
 
 export const isMemberOfDream = (currentUser, dream) => {
-  if (!currentUser || !dream) return false;
+  if (!currentUser || !dream || !currentUser.membership) return false;
   return dream.cocreators.reduce((res, member) => {
     if (member.id === currentUser.membership.id) return true;
     return res;


### PR DESCRIPTION
# Fixes ✅
When a registered user tries to enter a dream of event he doesn't have membership in (Didnt join) - he get an error and can't enter that dream - This fixes it.

This fixes the following
<img width="1288" alt="Screen Shot 2020-06-03 at 12 32 02" src="https://user-images.githubusercontent.com/1032526/83620631-3f115780-a596-11ea-9ce5-4a991f8fdf86.png">

# Alternative solution
An alternative (Perhaps better) fix would be to somehow set user.membership to default so when we check for fields such as `currentUser.membership.isAdmin` in the future we won't get an exception - Since I'm new into the code I'm not aware what's the best place to put it

# 🎩 Tophatting
Tested open an existing dream of a logged in use