### PR TITLE
Breadcrumbs

### DIFF
--- a/ui/components/Header/OrganizationAndEventHeader.js
+++ b/ui/components/Header/OrganizationAndEventHeader.js
@@ -66,7 +66,9 @@ export default ({currentOrg, event, currentUser}) => {
           <a
             className={`hover:bg-${event.color}-darker px-2 py-1 text-white rounded-md mx-0 font-medium`}
           >
-            <h1>{event.title}</h1>
+            <h1>{event.title.length <= 30 ?
+              event.title :
+              event.title.substr(0, 30)+ "..." }</h1>
           </a>
         </Link>
 
@@ -74,7 +76,11 @@ export default ({currentOrg, event, currentUser}) => {
         {dream && router.query?.dream && 
           <>
           <ChevronArrowRightIcon className={`w-5 h-5 text-white`} />
-          <span className={"px-2 py-1 text-white rounded-md mx-0 font-medium"}>{dream?.title}</span>
+          <span className={"px-2 py-1 text-white rounded-md mx-0 font-medium"}>
+            <h1>{dream.title.length <= 30 ?
+              dream.title :
+              dream.title.substr(0, 30)+ "..." }</h1>
+            </span>
           </>
         }
 

--- a/ui/components/Header/OrganizationAndEventHeader.js
+++ b/ui/components/Header/OrganizationAndEventHeader.js
@@ -1,0 +1,84 @@
+import { useState } from "react";
+import Link from "next/link";
+import { Tooltip } from "react-tippy";
+import { HomeIcon, DotsHorizontalIcon, ChevronArrowRightIcon } from "components/Icons";
+import EventSettingsModal from "components/EventSettingsModal";
+import IconButton from "components/IconButton";
+
+export default ({currentOrg, event, currentUser}) => {
+  const [eventSettingsModalOpen, setEventSettingsModalOpen] = useState(false);
+  return (
+    <>
+      <Tooltip
+        title={currentOrg?.name ?? `See all events`}
+        position="bottom"
+        size="small"
+      >
+        <div className="">
+          <Link href="/">
+            {currentOrg?.logo ? (
+              <a
+                className={
+                  "block rounded overflow-hidden opacity-50 hover:opacity-100 transition-opacity duration-100"
+                }
+              >
+                <img className="h-7 w-7" src={currentOrg?.logo} />
+              </a>
+            ) : (
+              <a
+                className={
+                  "block p-1 rounded-md " +
+                  (event.color
+                    ? `text-white opacity-75 hover:opacity-100 hover:bg-${event.color}-darker`
+                    : "hover:bg-gray-200 text-gray-500 hover:text-gray-800")
+                }
+              >
+                <HomeIcon className="h-5 w-5 " />
+              </a>
+            )}
+          </Link>
+        </div>
+      </Tooltip>
+
+      <ChevronArrowRightIcon className={`w-5 h-5 text-white`} />
+
+      <div className="group flex items-center">
+        <Link href="/[event]" as={`/${event.slug}`}>
+          <a
+            className={`hover:bg-${event.color}-darker px-2 py-1 text-white rounded-md mx-0 font-medium`}
+          >
+            <h1>{event.title}</h1>
+          </a>
+        </Link>
+        {(currentUser?.membership?.isAdmin ||
+          currentUser?.isOrgAdmin) && (
+          <>
+            <Tooltip
+              title="Event settings"
+              position="bottom"
+              size="small"
+            >
+              <IconButton
+                onClick={() => setEventSettingsModalOpen(true)}
+                className={
+                  event.color
+                    ? `text-white bg-${event.color} hover:bg-${event.color}-darker opacity-75 hover:opacity-100`
+                    : "text-gray-500 hover:text-gray-800"
+                }
+              >
+                <DotsHorizontalIcon className="h-4 w-4" />
+              </IconButton>
+            </Tooltip>
+            {eventSettingsModalOpen && (
+              <EventSettingsModal
+                event={event}
+                currentUser={currentUser}
+                handleClose={() => setEventSettingsModalOpen(false)}
+              />
+            )}
+          </>
+        )}
+      </div>
+    </>
+  )
+}

--- a/ui/components/Header/OrganizationAndEventHeader.js
+++ b/ui/components/Header/OrganizationAndEventHeader.js
@@ -1,12 +1,31 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
+import { useRouter } from "next/router";
+import { useQuery } from "@apollo/react-hooks";
+import gql from "graphql-tag";
 import { Tooltip } from "react-tippy";
 import { HomeIcon, DotsHorizontalIcon, ChevronArrowRightIcon } from "components/Icons";
 import EventSettingsModal from "components/EventSettingsModal";
 import IconButton from "components/IconButton";
 
+const DREAM_QUERY = gql`
+  query Dream($id: ID!) {
+    dream(id: $id) {
+      title
+    }
+  }
+`;
+
 export default ({currentOrg, event, currentUser}) => {
   const [eventSettingsModalOpen, setEventSettingsModalOpen] = useState(false);
+  const router = useRouter();
+  const { data: { dream } = { dream: null }, loading, error } = useQuery(
+    DREAM_QUERY,
+    {
+      variables: { id: router.query.dream },
+    }
+  );
+
   return (
     <>
       <Tooltip
@@ -50,6 +69,15 @@ export default ({currentOrg, event, currentUser}) => {
             <h1>{event.title}</h1>
           </a>
         </Link>
+
+        {/* We need to check both the dream and the router to prevent caching to appear */}
+        {dream && router.query?.dream && 
+          <>
+          <ChevronArrowRightIcon className={`w-5 h-5 text-white`} />
+          <span className={"px-2 py-1 text-white rounded-md mx-0 font-medium"}>{dream?.title}</span>
+          </>
+        }
+
         {(currentUser?.membership?.isAdmin ||
           currentUser?.isOrgAdmin) && (
           <>

--- a/ui/components/Header/OrganizationOnlyHeader.js
+++ b/ui/components/Header/OrganizationOnlyHeader.js
@@ -1,0 +1,17 @@
+import Link from "next/link";
+
+export default ({ currentOrg }) => (
+  <Link href="/">
+    <a className="flex">
+      {currentOrg?.logo && (
+        <img
+          className="h-7 w-7 block rounded overflow-hidden mr-4"
+          src={currentOrg.logo}
+        />
+      )}
+      <h1 className="text-lg font-medium text-gray-900 ">
+        {currentOrg?.name ?? "Dreams"}
+      </h1>
+    </a>
+  </Link>
+)

--- a/ui/components/Header/index.js
+++ b/ui/components/Header/index.js
@@ -2,16 +2,14 @@ import { useState } from "react";
 import Link from "next/link";
 import { Badge } from "@material-ui/core";
 import { useRouter } from "next/router";
-import { Tooltip } from "react-tippy";
 
 import ProfileDropdown from "components/ProfileDropdown";
 import Avatar from "components/Avatar";
 import LoginModal from "components/LoginModal";
 import { modals } from "components/Modal/index";
-import { HomeIcon, DotsHorizontalIcon } from "components/Icons";
-import EventSettingsModal from "components/EventSettingsModal";
 import NewDreamModal from "components/NewDreamModal";
-import IconButton from "components/IconButton";
+import OrganizationOnlyHeader from "./OrganizationOnlyHeader";
+import OrganizationAndEventHeader from "./OrganizationAndEventHeader";
 
 const css = {
   mobileProfileItem:
@@ -68,7 +66,6 @@ const NavItem = ({
 
 export default ({ event, currentUser, currentOrg, openModal, logOut }) => {
   const [isMenuOpen, setMenuOpen] = useState(false);
-  const [eventSettingsModalOpen, setEventSettingsModalOpen] = useState(false);
   const [loginModalOpen, setLoginModalOpen] = useState(false);
   const [newDreamModalOpen, setNewDreamModalOpen] = useState(false);
 
@@ -83,90 +80,12 @@ export default ({ event, currentUser, currentOrg, openModal, logOut }) => {
         <div className="flex items-center justify-between py-2 sm:p-0">
           <div className="flex items-center">
             {event ? (
-              <>
-                <Tooltip
-                  title={currentOrg?.name ?? `See all events`}
-                  position="bottom"
-                  size="small"
-                >
-                  <div className="">
-                    <Link href="/">
-                      {currentOrg?.logo ? (
-                        <a
-                          className={
-                            "block rounded overflow-hidden opacity-50 hover:opacity-100 transition-opacity duration-100"
-                          }
-                        >
-                          <img className="h-7 w-7" src={currentOrg?.logo} />
-                        </a>
-                      ) : (
-                        <a
-                          className={
-                            "block p-1 rounded-md " +
-                            (event.color
-                              ? `text-white opacity-75 hover:opacity-100 hover:bg-${event.color}-darker`
-                              : "hover:bg-gray-200 text-gray-500 hover:text-gray-800")
-                          }
-                        >
-                          <HomeIcon className="h-5 w-5 " />
-                        </a>
-                      )}
-                    </Link>
-                  </div>
-                </Tooltip>
-
-                <div className="group flex items-center">
-                  <Link href="/[event]" as={`/${event.slug}`}>
-                    <a
-                      className={`hover:bg-${event.color}-darker px-2 py-1 text-white rounded-md mx-2 font-medium`}
-                    >
-                      <h1>{event.title}</h1>
-                    </a>
-                  </Link>
-                  {(currentUser?.membership?.isAdmin ||
-                    currentUser?.isOrgAdmin) && (
-                    <>
-                      <Tooltip
-                        title="Event settings"
-                        position="bottom"
-                        size="small"
-                      >
-                        <IconButton
-                          onClick={() => setEventSettingsModalOpen(true)}
-                          className={
-                            event.color
-                              ? `text-white bg-${event.color} hover:bg-${event.color}-darker opacity-75 hover:opacity-100`
-                              : "text-gray-500 hover:text-gray-800"
-                          }
-                        >
-                          <DotsHorizontalIcon className="h-4 w-4" />
-                        </IconButton>
-                      </Tooltip>
-                      {eventSettingsModalOpen && (
-                        <EventSettingsModal
-                          event={event}
-                          currentUser={currentUser}
-                          handleClose={() => setEventSettingsModalOpen(false)}
-                        />
-                      )}
-                    </>
-                  )}
-                </div>
-              </>
+              <OrganizationAndEventHeader
+                currentOrg = {currentOrg}
+                event = {event}
+                currentUser = {currentUser} />
             ) : (
-              <Link href="/">
-                <a className="flex">
-                  {currentOrg?.logo && (
-                    <img
-                      className="h-7 w-7 block rounded overflow-hidden mr-4"
-                      src={currentOrg.logo}
-                    />
-                  )}
-                  <h1 className="text-lg font-medium text-gray-900 ">
-                    {currentOrg?.name ?? "Dreams"}
-                  </h1>
-                </a>
-              </Link>
+              <OrganizationOnlyHeader currentOrg = {currentOrg} />
             )}
           </div>
 

--- a/ui/components/Icons.js
+++ b/ui/components/Icons.js
@@ -305,3 +305,21 @@ export const FlagIcon = (props) => (
     />
   </svg>
 );
+
+//heroicons chevron-right
+export const ChevronArrowRightIcon = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    className="w-6 h-6"
+    {...props}>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      d="M9 5l7 7-7 7">
+    </path>
+  </svg>
+);


### PR DESCRIPTION
# Implements
- Added breadcrumbs to header (Actually just a small arrow between organization and event
- Refactored header
- Added new chevron arrow icon
- Should partly fix issue #107

<img width="559" alt="Screen Shot 2020-10-11 at 18 10 57" src="https://user-images.githubusercontent.com/1032526/95682348-65529e00-0bed-11eb-8a3e-9e29372d9837.png">

# Tophatting 🎩
- Tested that this works for anonymous users
- Tested that this works for logged in users
- Tested that this works for logged in admins
- Tested all 3 level pages - organization, event, dream page

# Open issues
We still need to figure out how to show dream data such as dream title in the header
