### PR TITLE
Fix buggy homepage info text clamp

### DIFF
--- a/ui/components/InfoBox.js
+++ b/ui/components/InfoBox.js
@@ -11,9 +11,7 @@ const InfoBox = ({ markdown, close }) => {
         "shadow rounded-lg mb-5 bg-white px-5 pt-4 pb-2 overflow-hidden "
       }
     >
-      <div
-        className={"relative markdown" + " " + (!expanded && "line-clamp-3")}
-      >
+      <div className={"relative markdown" + " " + (!expanded && "max-h-32")}>
         <ReactMarkdown source={markdown} />
 
         <div className="-mx-2">


### PR DESCRIPTION
Fixes https://github.com/Edgeryders-Participio/multi-dreams/issues/174

New look:

![image](https://user-images.githubusercontent.com/1427063/114405574-1c34d400-9ba7-11eb-9b66-48b4188140b7.png)

The old class was supposed to clamp the entire box to 3 lines but accidentally sort of clamped all the individual paragraphs to 3 lines