### PR TITLE
Add custom fields to discourse post

### DIFF
--- a/api/subscribers/discourse.subscriber.js
+++ b/api/subscribers/discourse.subscriber.js
@@ -172,6 +172,14 @@ module.exports = {
       content.push(dream.description);
     }
 
+    if (dream.customFields) {
+      dream.customFields.forEach( customField => {
+        const customFieldName = event.customFields.find(customEventField => String(customEventField._id) === String(customField.fieldId)).name
+        content.push(`## ${customFieldName}`);
+        content.push(customField.value)
+      });
+    }
+
     if (dream.budgetItems && dream.budgetItems.length > 0) {
       const income = dream.budgetItems.filter(({ type }) => type === 'INCOME');
       const expenses = dream.budgetItems.filter(({ type }) => type === 'EXPENSE');


### PR DESCRIPTION
Adds custom fields to Discourse version of Dream. 
Perhaps there is a smarter way to do this that is more in line with our standards. Let me know if that's the case.