### PR TITLE
Randomize order of dreams list, take 2

### DIFF
--- a/api/resolvers/index.js
+++ b/api/resolvers/index.js
@@ -184,13 +184,18 @@ const resolvers = {
           : othersQuery;
 
       const dreamsWithExtra = [
-        ...(await Dream.find(query, null, {
-          skip: offset,
-          limit: limit + 1,
-        }).sort({
-          createdAt: -1,
-        })),
-      ];
+        ...(await Dream.aggregate([
+          { $match: { eventId: mongoose.Types.ObjectId(event.id) } },
+        ])
+          .addFields({ potato: { $concat: ["$title", "asdf"] } })
+          .sort({
+            createdAt: -1,
+          })
+          .skip(offset)
+          .limit(limit + 1)),
+      ].map((d) => ({ ...d, id: d._id }));
+
+      console.log("dreamsextra", dreamsWithExtra);
 
       return {
         moreExist: dreamsWithExtra.length > limit,

--- a/api/resolvers/index.js
+++ b/api/resolvers/index.js
@@ -150,26 +150,29 @@ const resolvers = {
       const tagQuery = {
         ...(tag
           ? {
-              tags: tag,
+              tags: mongoose.Types.ObjectId(tag._id),
             }
           : null),
       };
 
       const adminQuery = {
-        eventId: event.id,
+        eventId: mongoose.Types.ObjectId(event.id),
         ...(textSearchTerm && { $text: { $search: textSearchTerm } }),
         ...tagQuery,
       };
       // todo: create appropriate index for this query
       // if event member, show dreams that are publisehd AND dreams where member is cocreator
       const memberQuery = {
-        eventId: event.id,
-        $or: [{ published: true }, { cocreators: currentEventMember?.id }],
+        eventId: mongoose.Types.ObjectId(event.id),
+        $or: [
+          { published: true },
+          { cocreators: mongoose.Types.ObjectId(currentEventMember?.id) },
+        ],
         ...(textSearchTerm && { $text: { $search: textSearchTerm } }),
         ...tagQuery,
       };
       const othersQuery = {
-        eventId: event.id,
+        eventId: mongoose.Types.ObjectId(event.id),
         published: true,
         ...(textSearchTerm && { $text: { $search: textSearchTerm } }),
         ...tagQuery,
@@ -184,9 +187,7 @@ const resolvers = {
           : othersQuery;
 
       const dreamsWithExtra = [
-        ...(await Dream.aggregate([
-          { $match: { eventId: mongoose.Types.ObjectId(event.id) } },
-        ])
+        ...(await Dream.aggregate([{ $match: query }])
           .addFields({ potato: { $concat: ["$title", "asdf"] } })
           .sort({
             createdAt: -1,

--- a/api/resolvers/index.js
+++ b/api/resolvers/index.js
@@ -188,9 +188,11 @@ const resolvers = {
 
       const dreamsWithExtra = [
         ...(await Dream.aggregate([{ $match: query }])
-          .addFields({ potato: { $concat: ["$title", "asdf"] } })
+          .addFields({
+            position: { $mod: [{ $toDouble: "$createdAt" }, 1000] },
+          })
           .sort({
-            createdAt: -1,
+            position: 1,
           })
           .skip(offset)
           .limit(limit + 1)),

--- a/api/resolvers/index.js
+++ b/api/resolvers/index.js
@@ -197,7 +197,12 @@ const resolvers = {
               $mod: [
                 {
                   $multiply: [
-                    { $mod: [{ $toDouble: "$createdAt" }, 1000] },
+                    {
+                      $mod: [
+                        { $toDouble: { $ifNull: ["$createdAt", 1] } },
+                        1000,
+                      ],
+                    },
                     userSeed,
                   ],
                 },


### PR DESCRIPTION
prev. https://github.com/Edgeryders-Participio/multi-dreams/pull/287

Added a fallback for dreams that don't have a createdAt field (which turns out to be the majority of them in production :grimacing: )

Tested with a dream with a null createdAt