### PR TITLE
Add id in sort for when dream positions collide

### DIFF
--- a/api/resolvers/index.js
+++ b/api/resolvers/index.js
@@ -212,6 +212,7 @@ const resolvers = {
           })
           .sort({
             position: 1,
+            _id: 1,
           })
           .skip(offset)
           .limit(limit + 1)),


### PR DESCRIPTION
When things get the same `position` field their sorting order is undefined, which can make pagination buggy. Addds _id to have the order always consistent

followup from https://github.com/Edgeryders-Participio/multi-dreams/pull/295