### PR TITLE
fix: user should be a collection member to post comments

### DIFF
--- a/api/resolvers/index.js
+++ b/api/resolvers/index.js
@@ -1202,13 +1202,26 @@ const resolvers = {
     addComment: async (
       parent,
       { content, dreamId },
-      { currentOrg, currentOrgMember, models: { Dream, Event }, eventHub }
+      {
+        currentOrg,
+        currentOrgMember,
+        models: { Dream, Event, EventMember },
+        eventHub,
+      }
     ) => {
       const dream = await Dream.findOne({ _id: dreamId });
       const event = await Event.findOne({ _id: dream.eventId });
+      const eventMember = await EventMember.findOne({
+        orgMemberId: currentOrgMember.id,
+        eventId: event.id,
+      });
 
       if (!currentOrgMember)
         throw new Error("You need to be an org member to post comments.");
+
+      if (!eventMember) {
+        throw new Error("You need to be a member of the collection to post comments.");
+      }
 
       if (orgHasDiscourse(currentOrg) && !currentOrgMember.discourseApiKey)
         throw new Error(

--- a/ui/components/Dream/Comments/index.js
+++ b/ui/components/Dream/Comments/index.js
@@ -32,7 +32,7 @@ const Comments = ({ currentOrgMember, currentOrg, dream, event, logs }) => {
           />
         );
       })}
-      {currentOrgMember && (
+      {currentOrgMember && currentOrgMember?.currentEventMembership && (
         <AddComment
           currentOrgMember={currentOrgMember}
           currentOrg={currentOrg}


### PR DESCRIPTION
Fixes Issue #263 

API throws an error if a user attempts to add a comment to a dream within a collection they are not a member of. UI does not display AddComment component if they are not collection member.

Screenshot:
![Screenshot from 2021-07-31 03-47-51](https://user-images.githubusercontent.com/26414988/127737496-4e198380-e872-4096-ada5-b4923cf964e9.png)
