### PR TITLE
Fix bug where discourse users without a dreams account are called Log

### DIFF
--- a/api/resolvers/index.js
+++ b/api/resolvers/index.js
@@ -29,12 +29,6 @@ const isMemberOfOrg = (parent, { id }, { kauth, currentOrgMember }) => {
   return skip;
 };
 
-const commentIsLog = (comment) => {
-  if (comment.isLog) return comment.isLog;
-  if (comment.authorId === undefined) return true; // system user
-  return false;
-};
-
 // const canEditEvent = (parent, args, { currentOrgMember, models }) => {
 //   // args: eventId
 //   //and you are either a orgAdmin or eventAdmin..
@@ -2698,9 +2692,6 @@ const resolvers = {
     },
   },
   Comment: {
-    isLog: (comment) => {
-      return commentIsLog(comment);
-    },
     orgMember: async (post, args, { currentOrg, models: { OrgMember } }) => {
       // make logs anonymous
       if (post.isLog) return null;

--- a/api/subscribers/discourse.subscriber.js
+++ b/api/subscribers/discourse.subscriber.js
@@ -10,6 +10,7 @@ module.exports = {
       id: post.id,
       createdAt: new Date(post.created_at),
       authorId: orgMember?.id,
+      isLog: post.username === "system",
       content: post.raw,
       htmlContent: post.cooked,
     };

--- a/ui/components/Dream/Comments/Comment.js
+++ b/ui/components/Dream/Comments/Comment.js
@@ -26,7 +26,6 @@ const Comment = ({ comment, showBorderBottom }) => {
     (currentOrgMember?.id === comment.orgMember?.id ||
       currentOrgMember?.currentEventMembership?.isAdmin);
 
-  console.log("comment render", comment);
   return (
     <div className="flex my-4">
       <div className="mr-4">
@@ -44,6 +43,8 @@ const Comment = ({ comment, showBorderBottom }) => {
         <div className="flex justify-between items-center mb-2 text-gray-900 font-medium text-sm">
           {comment.isLog ? (
             <h5>Log</h5>
+          ) : comment.orgMember === null ? (
+            <h5>A discourse user</h5>
           ) : (
             <h5>{comment.orgMember?.user.username}</h5>
           )}


### PR DESCRIPTION
Fixes https://github.com/Edgeryders-Participio/multi-dreams/issues/328

Not a perfect fix but now it's at least split up so only `system` is called log, and discourse users without a dreams account are called "A discourse user" so things are a bit clearer